### PR TITLE
feat: add Docker Compose setup for NATS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
 # SocialBot
 
 NATS Chatbot
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with the Compose plugin (v2+)
+- [Node.js](https://nodejs.org/) (see `package.json` for the required version)
+
+## Getting Started
+
+### 1. Start the NATS broker
+
+SocialBot uses [NATS](https://nats.io/) as its message broker. A `docker-compose.yml` is
+provided that starts a NATS server with TCP, WebSocket, and HTTP monitor ports exposed.
+
+```bash
+docker compose up -d
+```
+
+This starts a NATS container (`socialbot-nats`) with the following ports:
+
+| Port | Protocol  | Description          |
+| ---- | --------- | -------------------- |
+| 4222 | TCP/NATS  | Standard NATS client |
+| 8222 | HTTP      | NATS monitoring UI   |
+| 9222 | WebSocket | WebSocket clients    |
+
+You can verify the server is running by checking the monitor endpoint:
+
+```bash
+curl http://localhost:8222/varz
+```
+
+To stop the NATS container:
+
+```bash
+docker compose down
+```
+
+### 2. Install dependencies
+
+```bash
+npm install
+```
+
+### 3. Start the development server
+
+```bash
+npm run dev
+```
+
+## Running Tests
+
+```bash
+npm test
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  nats:
+    image: nats:latest
+    container_name: socialbot-nats
+    command: ["-c", "/etc/nats/nats-server.conf"]
+    ports:
+      - "4222:4222" # TCP/NATS
+      - "8222:8222" # HTTP monitor
+      - "9222:9222" # WebSocket
+    volumes:
+      - ./nats/nats-server.conf:/etc/nats/nats-server.conf:ro
+    restart: unless-stopped

--- a/nats/nats-server.conf
+++ b/nats/nats-server.conf
@@ -1,0 +1,13 @@
+# NATS Server Configuration for SocialBot
+
+# Standard TCP port for NATS clients
+port: 4222
+
+# HTTP monitoring endpoint
+http_port: 8222
+
+# WebSocket configuration
+websocket {
+  port: 9222
+  no_tls: true
+}


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` at repo root with a `nats` service using the official `nats:latest` image
- Add `nats/nats-server.conf` enabling WebSocket on port 9222 and HTTP monitor on port 8222
- Expose ports: `4222` (TCP/NATS), `8222` (HTTP monitor), `9222` (WebSocket)
- Update `README.md` with instructions to start the NATS container via `docker compose up -d`

## Test plan

- [ ] `docker compose up -d` exits 0 and `docker compose ps` shows the `socialbot-nats` container running
- [ ] `curl http://localhost:8222/varz` returns JSON with NATS server info
- [ ] A `nats` CLI or `wscat` can connect to `ws://localhost:9222` without error
- [ ] All project tests pass (`npm test`, `npm run lint`, `npm run format:check`)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)