### PR TITLE
feat: add CLI startup script that writes config.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "node scripts/start.js",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",

--- a/scripts/parseArgs.js
+++ b/scripts/parseArgs.js
@@ -1,0 +1,27 @@
+/**
+ * Parse --name and --topic flags from a list of CLI arguments.
+ *
+ * @param {string[]} args - Array of CLI argument strings (e.g. process.argv.slice(2))
+ * @param {{ name?: string, topic?: string }} [defaults] - Default values
+ * @returns {{ name: string, topic: string }}
+ */
+export function parseArgs(args, defaults = {}) {
+  const result = {
+    name: defaults.name ?? "User",
+    topic: defaults.topic ?? "chat",
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--name" && i + 1 < args.length) {
+      result.name = args[++i];
+    } else if (args[i] === "--topic" && i + 1 < args.length) {
+      result.topic = args[++i];
+    } else if (args[i].startsWith("--name=")) {
+      result.name = args[i].slice("--name=".length);
+    } else if (args[i].startsWith("--topic=")) {
+      result.topic = args[i].slice("--topic=".length);
+    }
+  }
+
+  return result;
+}

--- a/scripts/parseArgs.test.js
+++ b/scripts/parseArgs.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs } from "./parseArgs.js";
+
+describe("parseArgs", () => {
+  it("returns defaults when no arguments are provided", () => {
+    const result = parseArgs([]);
+    expect(result).toEqual({ name: "User", topic: "chat" });
+  });
+
+  it("parses --name flag with a space-separated value", () => {
+    const result = parseArgs(["--name", "Alice"]);
+    expect(result.name).toBe("Alice");
+    expect(result.topic).toBe("chat");
+  });
+
+  it("parses --topic flag with a space-separated value", () => {
+    const result = parseArgs(["--topic", "chat.room1"]);
+    expect(result.name).toBe("User");
+    expect(result.topic).toBe("chat.room1");
+  });
+
+  it("parses both --name and --topic flags", () => {
+    const result = parseArgs(["--name", "Bob", "--topic", "demo"]);
+    expect(result).toEqual({ name: "Bob", topic: "demo" });
+  });
+
+  it("parses --name=value syntax", () => {
+    const result = parseArgs(["--name=Charlie"]);
+    expect(result.name).toBe("Charlie");
+  });
+
+  it("parses --topic=value syntax", () => {
+    const result = parseArgs(["--topic=sports"]);
+    expect(result.topic).toBe("sports");
+  });
+
+  it("parses mixed flag styles", () => {
+    const result = parseArgs(["--name=Dave", "--topic", "news"]);
+    expect(result).toEqual({ name: "Dave", topic: "news" });
+  });
+
+  it("ignores unknown flags", () => {
+    const result = parseArgs(["--unknown", "value", "--name", "Eve"]);
+    expect(result.name).toBe("Eve");
+    expect(result.topic).toBe("chat");
+  });
+
+  it("accepts custom defaults", () => {
+    const result = parseArgs([], { name: "DefaultUser", topic: "general" });
+    expect(result).toEqual({ name: "DefaultUser", topic: "general" });
+  });
+
+  it("CLI args override custom defaults", () => {
+    const result = parseArgs(["--name", "Override"], { name: "DefaultUser", topic: "general" });
+    expect(result.name).toBe("Override");
+    expect(result.topic).toBe("general");
+  });
+});

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * SocialBot startup script.
+ *
+ * Parses --name and --topic CLI flags, writes public/config.json with those values,
+ * then spawns `vite dev`.
+ *
+ * Usage:
+ *   node scripts/start.js [--name <name>] [--topic <topic>]
+ *   npm start -- --name Alice --topic chat.room1
+ */
+
+import { writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "./parseArgs.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "..");
+
+const { name, topic } = parseArgs(process.argv.slice(2));
+
+const config = { name, topic };
+const configPath = resolve(projectRoot, "public", "config.json");
+
+writeFileSync(configPath, JSON.stringify(config) + "\n", "utf-8");
+console.log(`[start] Wrote ${configPath}:`, config);
+
+// Spawn vite dev — prefer local binary, fall back to npx
+const viteBin = resolve(projectRoot, "node_modules", ".bin", "vite");
+const child = spawn(viteBin, ["dev"], {
+  cwd: projectRoot,
+  stdio: "inherit",
+  shell: false,
+});
+
+child.on("error", (err) => {
+  // If local binary not found, retry with npx
+  if (err.code === "ENOENT") {
+    const fallback = spawn("npx", ["vite", "dev"], {
+      cwd: projectRoot,
+      stdio: "inherit",
+      shell: false,
+    });
+    fallback.on("error", (e) => {
+      console.error("[start] Failed to launch vite:", e.message);
+      process.exit(1);
+    });
+    fallback.on("exit", (code) => process.exit(code ?? 0));
+  } else {
+    console.error("[start] Failed to launch vite:", err.message);
+    process.exit(1);
+  }
+});
+
+child.on("exit", (code) => process.exit(code ?? 0));


### PR DESCRIPTION
## Summary

- Add `scripts/start.js` that parses `--name` and `--topic` CLI flags (defaults: `name=User`, `topic=chat`), writes `public/config.json`, then spawns `vite dev`
- Extract argument parsing into a pure function module `scripts/parseArgs.js` for testability
- Add 10 Vitest unit tests for the argument parsing logic (TDD — tests written first)
- Add `"start": "node scripts/start.js"` to `package.json` scripts

## Test plan

- [x] `npm test` — all 12 tests pass (10 parseArgs + 2 App)
- [x] `npm run lint` — no ESLint errors
- [x] `npm run format:check` — all files formatted correctly
- [x] `public/config.json` is already in `.gitignore` (from issue #1)
- [ ] Manual: `npm start -- --name Bob --topic demo` writes `{"name":"Bob","topic":"demo"}` to `public/config.json`
- [ ] Manual: `npm start` (no args) writes `{"name":"User","topic":"chat"}` and launches Vite at `http://localhost:5173`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)