### PR TITLE
feat: add NATS WebSocket client module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "socialbot",
       "version": "0.0.0",
       "dependencies": {
+        "nats.ws": "^1.30.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -3945,12 +3946,34 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nats.ws": {
+      "version": "1.30.3",
+      "resolved": "https://registry.npmjs.org/nats.ws/-/nats.ws-1.30.3.tgz",
+      "integrity": "sha512-aM77V2SEc+B6lbxCMZK3qfRy4jg8pmHj+wZzQKDiDIQYhLPj6U2NSHHBex0syj72Ayzl4uR5Lp3aKXTaVLbRpw==",
+      "license": "Apache-2.0",
+      "optionalDependencies": {
+        "nkeys.js": "1.1.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nkeys.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nkeys.js/-/nkeys.js-1.1.0.tgz",
+      "integrity": "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tweetnacl": "1.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -4665,6 +4688,13 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "nats.ws": "^1.30.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/src/nats/client.test.ts
+++ b/src/nats/client.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Hoist mock factories so vi.mock can reference them -----------------
+
+const { mockSubscribe, mockPublish, mockDrainConn, makeFakeSub } = vi.hoisted(() => {
+  const mockSubscribe = vi.fn();
+  const mockPublish = vi.fn();
+  const mockDrainConn = vi.fn().mockResolvedValue(undefined);
+
+  /** Creates a fake Subscription that yields one message then stops. */
+  function makeFakeSub(msgJson: string) {
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        yield { string: () => msgJson };
+      },
+      drain: vi.fn().mockResolvedValue(undefined),
+      unsubscribe: vi.fn(),
+    };
+  }
+
+  return { mockSubscribe, mockPublish, mockDrainConn, makeFakeSub };
+});
+
+// --- Mock nats.ws -------------------------------------------------------
+
+vi.mock("nats.ws", () => ({
+  connect: vi.fn().mockResolvedValue({
+    subscribe: mockSubscribe,
+    publish: mockPublish,
+    drain: mockDrainConn,
+  }),
+  StringCodec: vi.fn(() => ({
+    encode: (s: string) => new TextEncoder().encode(s),
+    decode: (u: Uint8Array) => new TextDecoder().decode(u),
+  })),
+}));
+
+// --- Import after mock setup -------------------------------------------
+
+import { connect, disconnect, onMessage, publish } from "./client";
+import type { NatsMessage } from "./client";
+
+// --- Tests -------------------------------------------------------------
+
+describe("NATS client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubscribe.mockReturnValue(makeFakeSub("{}"));
+    // Re-mock drain after clearAllMocks
+    mockDrainConn.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await disconnect();
+  });
+
+  describe("connect()", () => {
+    it("subscribes to the common topic", async () => {
+      await connect("ws://localhost:9222", "chat", "Alice");
+
+      const subjects = mockSubscribe.mock.calls.map((c) => c[0] as string);
+      expect(subjects).toContain("chat");
+    });
+
+    it("subscribes to the direct topic", async () => {
+      await connect("ws://localhost:9222", "chat", "Alice");
+
+      const subjects = mockSubscribe.mock.calls.map((c) => c[0] as string);
+      expect(subjects).toContain("chat.Alice");
+    });
+  });
+
+  describe("publish()", () => {
+    it("publishes to the common topic", async () => {
+      await connect("ws://localhost:9222", "chat", "Alice");
+      publish("hello");
+
+      expect(mockPublish).toHaveBeenCalledOnce();
+      expect(mockPublish.mock.calls[0][0]).toBe("chat");
+    });
+
+    it("sends the correct JSON wire format", async () => {
+      await connect("ws://localhost:9222", "chat", "Alice");
+      publish("hello");
+
+      const rawPayload = mockPublish.mock.calls[0][1] as Uint8Array;
+      const decoded = new TextDecoder().decode(rawPayload);
+      const parsed = JSON.parse(decoded) as NatsMessage;
+
+      expect(parsed.sender).toBe("Alice");
+      expect(parsed.text).toBe("hello");
+      expect(typeof parsed.timestamp).toBe("string");
+      // Timestamp should be a valid ISO-8601 date
+      expect(() => new Date(parsed.timestamp)).not.toThrow();
+    });
+  });
+
+  describe("onMessage()", () => {
+    it("invokes the callback for incoming messages", async () => {
+      const received: NatsMessage[] = [];
+      onMessage((msg) => received.push(msg));
+
+      const payload: NatsMessage = {
+        sender: "Bob",
+        text: "hi",
+        timestamp: new Date().toISOString(),
+      };
+      mockSubscribe.mockReturnValue(makeFakeSub(JSON.stringify(payload)));
+
+      await connect("ws://localhost:9222", "chat", "Alice");
+
+      // Allow the async iterators to drain
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(received.length).toBeGreaterThan(0);
+      expect(received[0].sender).toBe("Bob");
+      expect(received[0].text).toBe("hi");
+    });
+  });
+
+  describe("disconnect()", () => {
+    it("drains the connection", async () => {
+      await connect("ws://localhost:9222", "chat", "Alice");
+      await disconnect();
+
+      expect(mockDrainConn).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/nats/client.ts
+++ b/src/nats/client.ts
@@ -1,0 +1,137 @@
+import { StringCodec, connect as natsConnect } from "nats.ws";
+import type { NatsConnection, Subscription } from "nats.ws";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** The JSON wire-format for every message exchanged on the NATS bus. */
+export interface NatsMessage {
+  /** Display name of the sender. */
+  sender: string;
+  /** Plain-text message body. */
+  text: string;
+  /** ISO-8601 timestamp produced by the sender. */
+  timestamp: string;
+}
+
+/** Callback invoked for every inbound message. */
+export type MessageCallback = (msg: NatsMessage) => void;
+
+// ---------------------------------------------------------------------------
+// Module-level state
+// ---------------------------------------------------------------------------
+
+let nc: NatsConnection | null = null;
+let currentTopic: string = "";
+let currentName: string = "";
+let subscriptions: Subscription[] = [];
+let messageCallback: MessageCallback | null = null;
+
+const sc = StringCodec();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a callback that will be invoked whenever a message arrives on
+ * either the common or the direct subscription.  Call before ``connect`` so
+ * the callback is in place before any messages can arrive.
+ *
+ * :param cb: Function to call with each decoded ``NatsMessage``.
+ */
+export function onMessage(cb: MessageCallback): void {
+  messageCallback = cb;
+}
+
+/**
+ * Connect to the NATS server and subscribe to:
+ *
+ * - ``<topic>``         – the common/broadcast subject
+ * - ``<topic>.<name>``  – the direct/unicast subject for this client
+ *
+ * :param url:   WebSocket URL of the NATS server, e.g. ``ws://localhost:9222``.
+ * :param topic: Root subject name shared by all participants.
+ * :param name:  This client's identity, appended to form the direct subject.
+ * :returns:     A promise that resolves once the connection and subscriptions
+ *               are established.
+ */
+export async function connect(url: string, topic: string, name: string): Promise<void> {
+  // Clean up any existing connection first
+  await disconnect();
+
+  nc = await natsConnect({ servers: url });
+  currentTopic = topic;
+  currentName = name;
+
+  const commonSub = nc.subscribe(topic);
+  const directSub = nc.subscribe(`${topic}.${name}`);
+  subscriptions = [commonSub, directSub];
+
+  // Drain each subscription asynchronously, forwarding messages to the callback
+  for (const sub of subscriptions) {
+    void drainSubscription(sub);
+  }
+}
+
+/**
+ * Publish ``text`` to the common topic as a JSON-encoded ``NatsMessage``.
+ *
+ * :param text: The message body to broadcast.
+ * :raises Error: If ``connect`` has not been called yet.
+ */
+export function publish(text: string): void {
+  if (!nc) {
+    throw new Error("Not connected – call connect() first");
+  }
+
+  const message: NatsMessage = {
+    sender: currentName,
+    text,
+    timestamp: new Date().toISOString(),
+  };
+
+  nc.publish(currentTopic, sc.encode(JSON.stringify(message)));
+}
+
+/**
+ * Drain and close the current NATS connection.  Safe to call even when not
+ * connected.
+ *
+ * :returns: A promise that resolves once the connection is fully closed.
+ */
+export async function disconnect(): Promise<void> {
+  if (!nc) return;
+
+  const conn = nc;
+  nc = null;
+  subscriptions = [];
+  currentTopic = "";
+  currentName = "";
+
+  await conn.drain();
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Asynchronously iterate over a subscription and forward each message to the
+ * registered callback.  Parse errors are silently ignored so that malformed
+ * messages cannot crash the client.
+ *
+ * :param sub: The ``Subscription`` to iterate.
+ */
+async function drainSubscription(sub: Subscription): Promise<void> {
+  for await (const msg of sub) {
+    if (!messageCallback) continue;
+    try {
+      const parsed = JSON.parse(msg.string()) as NatsMessage;
+      messageCallback(parsed);
+    } catch {
+      // Ignore malformed messages
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/nats/client.ts` — a pure TypeScript NATS WebSocket client using `nats.ws`
- Exports `connect(url, topic, name)`, `publish(text)`, `disconnect()`, and `onMessage(cb)` 
- On connect, subscribes to both `<topic>` (common/broadcast) and `<topic>.<name>` (direct/unicast)
- Wire format: `{ sender, text, timestamp }` JSON-encoded via `StringCodec`
- Adds `src/nats/client.test.ts` with 6 Vitest unit tests using `vi.mock` and `vi.hoisted`

## Test plan

- [x] All 8 tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`npm run format:check`)
- [ ] Manual: with Docker NATS running, `connect()` resolves in browser console
- [ ] Manual: `publish()` from console appears on `<topic>` subject via `curl http://localhost:8222/subsz`

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)