### PR TITLE
feat: add settings panel with localStorage history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "happy-dom": "^20.7.0",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.3",
         "prettier": "^3.5.3",
@@ -1953,6 +1954,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1971,6 +1982,23 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3287,6 +3315,47 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.7.0.tgz",
+      "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4716,6 +4785,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "happy-dom": "^20.7.0",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.3",
     "prettier": "^3.5.3",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,15 +1,32 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import App from "./App";
 
+const mockConfig = { name: "Alice", topic: "chat.room1" };
+
 describe("App", () => {
-  it("renders the SocialBot heading", () => {
-    render(<App />);
-    expect(screen.getByRole("heading", { name: /socialbot/i })).toBeDefined();
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockConfig),
+      }),
+    );
   });
 
-  it("renders a subtitle", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the settings panel on startup", async () => {
     render(<App />);
-    expect(screen.getByText(/coming soon/i)).toBeDefined();
+    expect(await screen.findByRole("button", { name: /connect/i })).toBeDefined();
+  });
+
+  it("renders name and topic inputs", async () => {
+    render(<App />);
+    expect(await screen.findByLabelText(/name/i)).toBeDefined();
+    expect(await screen.findByLabelText(/topic/i)).toBeDefined();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,23 @@
+import { useState } from "react";
 import "./App.css";
+import SettingsPanel from "./settings/SettingsPanel";
+import type { HistoryEntry } from "./settings/useSettingsHistory";
 
 function App() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-gray-900 text-white">
-      <h1 className="text-4xl font-bold">SocialBot</h1>
-      <p className="mt-4 text-gray-400">NATS Chatbot — coming soon</p>
-    </main>
-  );
+  const [connection, setConnection] = useState<HistoryEntry | null>(null);
+
+  if (connection) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center bg-gray-900 text-white">
+        <div className="text-xl font-semibold">
+          Connected as <span className="text-blue-400">{connection.name}</span> to{" "}
+          <span className="text-green-400">{connection.topic}</span>
+        </div>
+      </main>
+    );
+  }
+
+  return <SettingsPanel onConnect={setConnection} />;
 }
 
 export default App;

--- a/src/settings/SettingsPanel.test.tsx
+++ b/src/settings/SettingsPanel.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsPanel from "./SettingsPanel";
+
+const mockConfig = { name: "Alice", topic: "chat.room1" };
+
+function makeFetchMock(config = mockConfig) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(config),
+  });
+}
+
+describe("SettingsPanel", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal("fetch", makeFetchMock());
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders a name input field", async () => {
+    render(<SettingsPanel onConnect={() => {}} />);
+    expect(await screen.findByLabelText(/name/i)).toBeDefined();
+  });
+
+  it("renders a topic input field", async () => {
+    render(<SettingsPanel onConnect={() => {}} />);
+    expect(await screen.findByLabelText(/topic/i)).toBeDefined();
+  });
+
+  it("renders a Connect button", async () => {
+    render(<SettingsPanel onConnect={() => {}} />);
+    expect(await screen.findByRole("button", { name: /connect/i })).toBeDefined();
+  });
+
+  it("pre-fills name and topic from config.json", async () => {
+    render(<SettingsPanel onConnect={() => {}} />);
+
+    const nameInput = await screen.findByLabelText(/name/i);
+    const topicInput = await screen.findByLabelText(/topic/i);
+
+    await waitFor(() => {
+      expect((nameInput as HTMLInputElement).value).toBe("Alice");
+      expect((topicInput as HTMLInputElement).value).toBe("chat.room1");
+    });
+  });
+
+  it("calls onConnect with current name and topic when Connect is clicked", async () => {
+    const onConnect = vi.fn();
+    const user = userEvent.setup();
+
+    render(<SettingsPanel onConnect={onConnect} />);
+
+    // Wait for the form to be populated from config
+    await waitFor(() => {
+      const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+      expect(nameInput.value).toBe("Alice");
+    });
+
+    await user.click(screen.getByRole("button", { name: /connect/i }));
+
+    expect(onConnect).toHaveBeenCalledWith({ name: "Alice", topic: "chat.room1" });
+  });
+
+  it("allows changing name before connecting", async () => {
+    const onConnect = vi.fn();
+    const user = userEvent.setup();
+
+    render(<SettingsPanel onConnect={onConnect} />);
+
+    const nameInput = await screen.findByLabelText(/name/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Bob");
+
+    await user.click(screen.getByRole("button", { name: /connect/i }));
+
+    expect(onConnect).toHaveBeenCalledWith({ name: "Bob", topic: "chat.room1" });
+  });
+
+  it("saves name+topic to localStorage history on connect", async () => {
+    const user = userEvent.setup();
+
+    render(<SettingsPanel onConnect={() => {}} />);
+
+    await waitFor(() => {
+      const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+      expect(nameInput.value).toBe("Alice");
+    });
+
+    await user.click(screen.getByRole("button", { name: /connect/i }));
+
+    const stored = JSON.parse(localStorage.getItem("socialbot:history") ?? "[]");
+    expect(stored).toEqual([{ name: "Alice", topic: "chat.room1" }]);
+  });
+
+  it("shows history options from localStorage in the name datalist", async () => {
+    localStorage.setItem(
+      "socialbot:history",
+      JSON.stringify([
+        { name: "Bob", topic: "chat.room2" },
+        { name: "Alice", topic: "chat.room1" },
+      ]),
+    );
+
+    render(<SettingsPanel onConnect={() => {}} />);
+
+    await waitFor(() => {
+      const options = document.querySelectorAll("#name-history option");
+      const values = Array.from(options).map((o) => o.getAttribute("value"));
+      expect(values).toContain("Bob");
+      expect(values).toContain("Alice");
+    });
+  });
+});

--- a/src/settings/SettingsPanel.tsx
+++ b/src/settings/SettingsPanel.tsx
@@ -1,0 +1,112 @@
+import { useState, useEffect } from "react";
+import { useSettingsHistory, type HistoryEntry } from "./useSettingsHistory";
+
+interface SettingsPanelProps {
+  /** Called when the user clicks "Connect" with the chosen name and topic. */
+  onConnect: (entry: HistoryEntry) => void;
+}
+
+/**
+ * Settings panel displayed on startup. Fetches ``/config.json`` to get default
+ * name and topic, shows combobox inputs populated from localStorage history, and
+ * calls ``onConnect`` when the user submits the form.
+ */
+function SettingsPanel({ onConnect }: SettingsPanelProps) {
+  const { history, addEntry } = useSettingsHistory();
+  const [name, setName] = useState("");
+  const [topic, setTopic] = useState("");
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    fetch("/config.json")
+      .then((res) => res.json())
+      .then((config: { name?: string; topic?: string }) => {
+        setName(config.name ?? "");
+        setTopic(config.topic ?? "");
+        setLoaded(true);
+      })
+      .catch(() => {
+        setLoaded(true);
+      });
+  }, []);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const entry: HistoryEntry = { name, topic };
+    addEntry(entry);
+    onConnect(entry);
+  }
+
+  if (!loaded) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center bg-gray-900 text-white">
+        <p className="text-gray-400">Loading…</p>
+      </main>
+    );
+  }
+
+  const nameOptions = Array.from(new Set(history.map((e) => e.name)));
+  const topicOptions = Array.from(new Set(history.map((e) => e.topic)));
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gray-900 text-white">
+      <div className="w-full max-w-sm rounded-xl bg-gray-800 p-8 shadow-lg">
+        <h1 className="mb-6 text-center text-2xl font-bold">SocialBot</h1>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <label htmlFor="name-input" className="text-sm font-medium text-gray-300">
+              Name
+            </label>
+            <input
+              id="name-input"
+              aria-label="Name"
+              type="text"
+              list="name-history"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-white focus:border-blue-500 focus:outline-none"
+              placeholder="Your name"
+            />
+            <datalist id="name-history">
+              {nameOptions.map((n) => (
+                <option key={n} value={n} />
+              ))}
+            </datalist>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="topic-input" className="text-sm font-medium text-gray-300">
+              Topic
+            </label>
+            <input
+              id="topic-input"
+              aria-label="Topic"
+              type="text"
+              list="topic-history"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              required
+              className="rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-white focus:border-blue-500 focus:outline-none"
+              placeholder="NATS topic (e.g. chat.room1)"
+            />
+            <datalist id="topic-history">
+              {topicOptions.map((t) => (
+                <option key={t} value={t} />
+              ))}
+            </datalist>
+          </div>
+
+          <button
+            type="submit"
+            className="mt-2 rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+          >
+            Connect
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}
+
+export default SettingsPanel;

--- a/src/settings/useSettingsHistory.test.ts
+++ b/src/settings/useSettingsHistory.test.ts
@@ -1,0 +1,119 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSettingsHistory } from "./useSettingsHistory";
+
+const STORAGE_KEY = "socialbot:history";
+
+describe("useSettingsHistory", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns empty history initially when localStorage is empty", () => {
+    const { result } = renderHook(() => useSettingsHistory());
+    expect(result.current.history).toEqual([]);
+  });
+
+  it("adds an entry to history", () => {
+    const { result } = renderHook(() => useSettingsHistory());
+
+    act(() => {
+      result.current.addEntry({ name: "Alice", topic: "chat.room1" });
+    });
+
+    expect(result.current.history).toEqual([{ name: "Alice", topic: "chat.room1" }]);
+  });
+
+  it("adds multiple entries, most recent first", () => {
+    const { result } = renderHook(() => useSettingsHistory());
+
+    act(() => {
+      result.current.addEntry({ name: "Alice", topic: "chat.room1" });
+    });
+    act(() => {
+      result.current.addEntry({ name: "Bob", topic: "chat.room2" });
+    });
+
+    expect(result.current.history).toEqual([
+      { name: "Bob", topic: "chat.room2" },
+      { name: "Alice", topic: "chat.room1" },
+    ]);
+  });
+
+  it("deduplicates identical name+topic pairs (moves to front)", () => {
+    const { result } = renderHook(() => useSettingsHistory());
+
+    act(() => {
+      result.current.addEntry({ name: "Alice", topic: "chat.room1" });
+    });
+    act(() => {
+      result.current.addEntry({ name: "Bob", topic: "chat.room2" });
+    });
+    act(() => {
+      result.current.addEntry({ name: "Alice", topic: "chat.room1" });
+    });
+
+    expect(result.current.history).toEqual([
+      { name: "Alice", topic: "chat.room1" },
+      { name: "Bob", topic: "chat.room2" },
+    ]);
+    expect(result.current.history).toHaveLength(2);
+  });
+
+  it("does not add a duplicate of the exact same entry", () => {
+    const { result } = renderHook(() => useSettingsHistory());
+
+    act(() => {
+      result.current.addEntry({ name: "Alice", topic: "chat.room1" });
+    });
+    act(() => {
+      result.current.addEntry({ name: "Alice", topic: "chat.room1" });
+    });
+
+    expect(result.current.history).toHaveLength(1);
+  });
+
+  it("persists entries to localStorage", () => {
+    const { result } = renderHook(() => useSettingsHistory());
+
+    act(() => {
+      result.current.addEntry({ name: "Alice", topic: "chat.room1" });
+    });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+    expect(stored).toEqual([{ name: "Alice", topic: "chat.room1" }]);
+  });
+
+  it("reads existing history from localStorage on mount", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { name: "Bob", topic: "chat.room2" },
+        { name: "Alice", topic: "chat.room1" },
+      ]),
+    );
+
+    const { result } = renderHook(() => useSettingsHistory());
+
+    expect(result.current.history).toEqual([
+      { name: "Bob", topic: "chat.room2" },
+      { name: "Alice", topic: "chat.room1" },
+    ]);
+  });
+
+  it("persists across hook re-renders (simulated remount)", () => {
+    const { result: result1 } = renderHook(() => useSettingsHistory());
+
+    act(() => {
+      result1.current.addEntry({ name: "Alice", topic: "chat.room1" });
+    });
+
+    // Simulate a new component instance reading from localStorage
+    const { result: result2 } = renderHook(() => useSettingsHistory());
+    expect(result2.current.history).toEqual([{ name: "Alice", topic: "chat.room1" }]);
+  });
+});

--- a/src/settings/useSettingsHistory.ts
+++ b/src/settings/useSettingsHistory.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from "react";
+
+/** A name+topic pair stored in localStorage history. */
+export interface HistoryEntry {
+  name: string;
+  topic: string;
+}
+
+const STORAGE_KEY = "socialbot:history";
+
+function loadHistory(): HistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as HistoryEntry[];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(entries: HistoryEntry[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+}
+
+interface UseSettingsHistoryResult {
+  /** Ordered list of history entries, most recent first. */
+  history: HistoryEntry[];
+  /** Add a new entry, deduplicating by name+topic (moves to front if already exists). */
+  addEntry: (entry: HistoryEntry) => void;
+}
+
+/**
+ * Custom hook for reading and writing the settings history stored in localStorage
+ * under the key ``"socialbot:history"``. Entries are stored as a JSON array of
+ * ``{name, topic}`` objects, most recent first. Duplicate name+topic pairs are
+ * deduplicated — the existing entry is removed and the new one is placed at the front.
+ */
+export function useSettingsHistory(): UseSettingsHistoryResult {
+  const [history, setHistory] = useState<HistoryEntry[]>(() => loadHistory());
+
+  const addEntry = useCallback((entry: HistoryEntry) => {
+    setHistory((prev) => {
+      // Remove any existing entry with the same name+topic
+      const filtered = prev.filter((e) => !(e.name === entry.name && e.topic === entry.topic));
+      const updated = [entry, ...filtered];
+      saveHistory(updated);
+      return updated;
+    });
+  }, []);
+
+  return { history, addEntry };
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,42 @@
+/**
+ * Vitest global setup file.
+ *
+ * Node.js 22+ exposes a built-in ``localStorage`` (backed by a file) that conflicts
+ * with jsdom/happy-dom's in-memory implementation. We replace it with a simple
+ * in-memory ``Storage`` shim before each test so that ``localStorage.clear()``,
+ * ``setItem()``, ``getItem()``, and ``removeItem()`` work as expected.
+ */
+import { beforeEach } from "vitest";
+
+function createInMemoryStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    key(index: number): string | null {
+      return Object.keys(store)[index] ?? null;
+    },
+    getItem(key: string): string | null {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    setItem(key: string, value: string): void {
+      store[key] = String(value);
+    },
+    removeItem(key: string): void {
+      delete store[key];
+    },
+    clear(): void {
+      store = {};
+    },
+  };
+}
+
+beforeEach(() => {
+  const storage = createInMemoryStorage();
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    writable: true,
+    configurable: true,
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    setupFiles: ["./src/test-setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- Adds `SettingsPanel` component that fetches `/config.json` on load for default name/topic values
- Shows name and topic as combobox inputs (`<datalist>`-backed) with options from localStorage history
- On "Connect", saves the name+topic entry to localStorage (deduplicated, most recent first) and transitions to a placeholder chat view
- Adds `useSettingsHistory` custom hook encapsulating all localStorage read/write logic
- Adds a vitest `test-setup.ts` that installs an in-memory `localStorage` shim to work around Node.js 25's built-in `localStorage` (which lacks `clear()`) interfering with jsdom tests

## Test plan

- [ ] `npm test` — all 28 tests pass (8 hook tests, 8 panel component tests, 2 app tests, 10 parseArgs tests)
- [ ] `npm run lint` — no lint errors
- [ ] `npm run format:check` — all files properly formatted
- [ ] `npm start -- --name Alice --topic chat.room1` → Settings panel shows Alice / chat.room1 pre-selected
- [ ] Change name to "Bob", click Connect → "Connected as Bob to chat.room1" appears
- [ ] Reload page → Bob appears in the name dropdown history
- [ ] Start with different name → Alice still appears as an option

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)