### PR TITLE
feat: add chat UI with NATS wiring and deterministic sender colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,14 @@
 import { useState } from "react";
 import "./App.css";
 import SettingsPanel from "./settings/SettingsPanel";
+import ChatView from "./chat/ChatView";
 import type { HistoryEntry } from "./settings/useSettingsHistory";
 
 function App() {
   const [connection, setConnection] = useState<HistoryEntry | null>(null);
 
   if (connection) {
-    return (
-      <main className="flex min-h-screen flex-col items-center justify-center bg-gray-900 text-white">
-        <div className="text-xl font-semibold">
-          Connected as <span className="text-blue-400">{connection.name}</span> to{" "}
-          <span className="text-green-400">{connection.topic}</span>
-        </div>
-      </main>
-    );
+    return <ChatView name={connection.name} topic={connection.topic} />;
   }
 
   return <SettingsPanel onConnect={setConnection} />;

--- a/src/chat/ChatView.test.tsx
+++ b/src/chat/ChatView.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ChatView from "./ChatView";
+import type { MessageCallback } from "../nats/client";
+
+// Mock the entire NATS client module
+vi.mock("../nats/client", () => {
+  let _callback: MessageCallback | null = null;
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    publish: vi.fn(),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    onMessage: vi.fn((cb: MessageCallback) => {
+      _callback = cb;
+    }),
+    // Expose for tests to trigger incoming messages
+    __trigger: (msg: Parameters<MessageCallback>[0]) => _callback?.(msg),
+  };
+});
+
+import * as natsClient from "../nats/client";
+const trigger = (
+  natsClient as unknown as { __trigger: (msg: Parameters<MessageCallback>[0]) => void }
+).__trigger;
+
+describe("ChatView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a message input and send button", () => {
+    render(<ChatView name="Alice" topic="chat" />);
+    expect(screen.getByPlaceholderText(/message/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: /send/i })).toBeDefined();
+  });
+
+  it("connects to NATS on mount", async () => {
+    render(<ChatView name="Alice" topic="chat" />);
+    await waitFor(() => {
+      expect(natsClient.connect).toHaveBeenCalledWith("ws://localhost:9222", "chat", "Alice");
+    });
+  });
+
+  it("publishes message text when Send is clicked", async () => {
+    render(<ChatView name="Alice" topic="chat" />);
+    const input = screen.getByPlaceholderText(/message/i);
+    fireEvent.change(input, { target: { value: "Hello world" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(natsClient.publish).toHaveBeenCalledWith("Hello world");
+  });
+
+  it("shows own message immediately after sending (optimistic)", async () => {
+    render(<ChatView name="Alice" topic="chat" />);
+    const input = screen.getByPlaceholderText(/message/i);
+    fireEvent.change(input, { target: { value: "Optimistic message" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(screen.getByText("Optimistic message")).toBeDefined();
+  });
+
+  it("clears the input after sending", () => {
+    render(<ChatView name="Alice" topic="chat" />);
+    const input = screen.getByPlaceholderText(/message/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(input.value).toBe("");
+  });
+
+  it("submits on Enter key", () => {
+    render(<ChatView name="Alice" topic="chat" />);
+    const input = screen.getByPlaceholderText(/message/i);
+    fireEvent.change(input, { target: { value: "Enter message" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    expect(natsClient.publish).toHaveBeenCalledWith("Enter message");
+  });
+
+  it("displays incoming messages from NATS", async () => {
+    render(<ChatView name="Alice" topic="chat" />);
+    await waitFor(() => expect(natsClient.onMessage).toHaveBeenCalled());
+    trigger({ sender: "Bob", text: "Hi Alice!", timestamp: new Date().toISOString() });
+    await waitFor(() => {
+      expect(screen.getByText("Hi Alice!")).toBeDefined();
+    });
+  });
+
+  it("renders sender names in the message list", async () => {
+    render(<ChatView name="Alice" topic="chat" />);
+    await waitFor(() => expect(natsClient.onMessage).toHaveBeenCalled());
+    trigger({ sender: "Bob", text: "Hey there", timestamp: new Date().toISOString() });
+    await waitFor(() => {
+      expect(screen.getByText("Bob")).toBeDefined();
+    });
+  });
+
+  it("renders sender name with a color class", async () => {
+    render(<ChatView name="Alice" topic="chat" />);
+    await waitFor(() => expect(natsClient.onMessage).toHaveBeenCalled());
+    trigger({ sender: "Carol", text: "Color test", timestamp: new Date().toISOString() });
+    await waitFor(() => {
+      const senderEl = screen.getByText("Carol");
+      // Should have one of the color classes
+      expect(senderEl.className).toMatch(/text-\w+-400/);
+    });
+  });
+
+  it("disconnects on unmount", async () => {
+    const { unmount } = render(<ChatView name="Alice" topic="chat" />);
+    unmount();
+    await waitFor(() => {
+      expect(natsClient.disconnect).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -1,0 +1,118 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { connect, publish, disconnect, onMessage } from "../nats/client";
+import type { NatsMessage } from "../nats/client";
+import { senderColor } from "./senderColor";
+
+interface ChatViewProps {
+  name: string;
+  topic: string;
+  natsUrl?: string;
+}
+
+interface Message extends NatsMessage {
+  id: string;
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+/**
+ * Main chat view: scrolling message list wired to NATS, plus a send form.
+ *
+ * :param name:    The local user's display name.
+ * :param topic:   The NATS subject to publish and subscribe on.
+ * :param natsUrl: WebSocket URL of the NATS server (default: ws://localhost:9222).
+ */
+function ChatView({ name, topic, natsUrl = "ws://localhost:9222" }: ChatViewProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [text, setText] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const counterRef = useRef(0);
+
+  const nextId = () => {
+    counterRef.current += 1;
+    return `msg-${counterRef.current}`;
+  };
+
+  const appendMessage = useCallback((msg: NatsMessage) => {
+    setMessages((prev) => [...prev, { ...msg, id: nextId() }]);
+  }, []);
+
+  useEffect(() => {
+    onMessage(appendMessage);
+    void connect(natsUrl, topic, name);
+    return () => {
+      void disconnect();
+    };
+  }, [name, topic, natsUrl, appendMessage]);
+
+  // Auto-scroll to bottom when messages change
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView?.({ behavior: "smooth" });
+  }, [messages]);
+
+  function handleSend() {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    // Optimistic: add to local state immediately
+    appendMessage({ sender: name, text: trimmed, timestamp: new Date().toISOString() });
+    publish(trimmed);
+    setText("");
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      handleSend();
+    }
+  }
+
+  return (
+    <main className="flex h-screen flex-col bg-gray-900 text-white">
+      {/* Header */}
+      <header className="flex items-center gap-3 border-b border-gray-700 px-4 py-3">
+        <span className="font-semibold text-white">{name}</span>
+        <span className="text-gray-400">→</span>
+        <span className="font-mono text-sm text-green-400">{topic}</span>
+      </header>
+
+      {/* Message list */}
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        {messages.map((msg) => (
+          <div key={msg.id} className="mb-3">
+            <div className="flex items-baseline gap-2">
+              <span className={`text-sm font-semibold ${senderColor(msg.sender)}`}>
+                {msg.sender}
+              </span>
+              <span className="text-xs text-gray-500">{formatTime(msg.timestamp)}</span>
+            </div>
+            <p className="mt-0.5 text-gray-100">{msg.text}</p>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Send form */}
+      <div className="border-t border-gray-700 px-4 py-3">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a message…"
+            className="flex-1 rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+          />
+          <button
+            onClick={handleSend}
+            className="rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export default ChatView;

--- a/src/chat/senderColor.test.ts
+++ b/src/chat/senderColor.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { senderColor, COLORS } from "./senderColor";
+
+describe("senderColor", () => {
+  it("returns the same color for the same name", () => {
+    expect(senderColor("Alice")).toBe(senderColor("Alice"));
+    expect(senderColor("Bob")).toBe(senderColor("Bob"));
+    expect(senderColor("Carol")).toBe(senderColor("Carol"));
+  });
+
+  it("returns a valid Tailwind color class", () => {
+    expect(COLORS).toContain(senderColor("Alice"));
+    expect(COLORS).toContain(senderColor("Bob"));
+    expect(COLORS).toContain(senderColor(""));
+  });
+
+  it("different names can return different colors", () => {
+    const colors = new Set(
+      ["Alice", "Bob", "Carol", "Dave", "Eve", "Frank", "Grace", "Heidi"].map(senderColor),
+    );
+    expect(colors.size).toBeGreaterThan(1);
+  });
+
+  it("is consistent across multiple calls", () => {
+    const name = "TestUser";
+    const first = senderColor(name);
+    for (let i = 0; i < 10; i++) {
+      expect(senderColor(name)).toBe(first);
+    }
+  });
+});

--- a/src/chat/senderColor.ts
+++ b/src/chat/senderColor.ts
@@ -1,0 +1,27 @@
+const COLORS = [
+  "text-red-400",
+  "text-blue-400",
+  "text-green-400",
+  "text-yellow-400",
+  "text-purple-400",
+  "text-pink-400",
+  "text-orange-400",
+  "text-cyan-400",
+];
+
+/**
+ * Returns a deterministic Tailwind color class for a sender name.
+ * Uses a djb2 hash so the same name always maps to the same color.
+ *
+ * :param name: The sender's display name.
+ * :returns:    A Tailwind text color class string.
+ */
+export function senderColor(name: string): string {
+  let hash = 5381;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 33) ^ name.charCodeAt(i);
+  }
+  return COLORS[Math.abs(hash) % COLORS.length];
+}
+
+export { COLORS };


### PR DESCRIPTION
## Summary

- Adds `ChatView` component with scrolling message list, header showing name/topic, and send form
- Sender names are color-coded using djb2 hash → one of 8 Tailwind color classes (same name = same color across all instances)
- Own messages appear immediately via optimistic update (no waiting for NATS echo)
- Connects to NATS on mount, registers `onMessage` callback, disconnects on unmount
- Enter key or Send button both publish messages
- Adds `senderColor(name)` pure function in its own module for easy testing

## Test plan

- [x] `npm test` — 48 tests pass (10 ChatView, 4 senderColor, 2 App, 8 SettingsPanel, 8 useSettingsHistory, 6 nats/client, 10 parseArgs)
- [x] `npm run lint` — ESLint clean
- [x] `npm run format:check` — Prettier clean

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)