### PR TITLE
fix: require onMessage callback at connect time (#16)

### DIFF
--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { connect, publish, disconnect, onMessage } from "../nats/client";
+import { connect, publish, disconnect } from "../nats/client";
 import type { NatsMessage } from "../nats/client";
 import { senderColor } from "./senderColor";
 
@@ -40,8 +40,7 @@ function ChatView({ name, topic, natsUrl = "ws://localhost:9222" }: ChatViewProp
   }, []);
 
   useEffect(() => {
-    onMessage(appendMessage);
-    void connect(natsUrl, topic, name);
+    void connect(natsUrl, topic, name, appendMessage);
     return () => {
       void disconnect();
     };

--- a/src/nats/client.test.ts
+++ b/src/nats/client.test.ts
@@ -37,7 +37,7 @@ vi.mock("nats.ws", () => ({
 
 // --- Import after mock setup -------------------------------------------
 
-import { connect, disconnect, onMessage, publish } from "./client";
+import { connect, disconnect, publish } from "./client";
 import type { NatsMessage } from "./client";
 
 // --- Tests -------------------------------------------------------------
@@ -56,23 +56,50 @@ describe("NATS client", () => {
 
   describe("connect()", () => {
     it("subscribes to the common topic", async () => {
-      await connect("ws://localhost:9222", "chat", "Alice");
+      await connect("ws://localhost:9222", "chat", "Alice", vi.fn());
 
       const subjects = mockSubscribe.mock.calls.map((c) => c[0] as string);
       expect(subjects).toContain("chat");
     });
 
     it("subscribes to the direct topic", async () => {
-      await connect("ws://localhost:9222", "chat", "Alice");
+      await connect("ws://localhost:9222", "chat", "Alice", vi.fn());
 
       const subjects = mockSubscribe.mock.calls.map((c) => c[0] as string);
       expect(subjects).toContain("chat.Alice");
+    });
+
+    it("accepts the onMessage callback as a required fourth argument", async () => {
+      const cb = vi.fn();
+      // Should not throw
+      await expect(connect("ws://localhost:9222", "chat", "Alice", cb)).resolves.toBeUndefined();
+    });
+
+    it("invokes the callback for incoming messages passed at connect time", async () => {
+      const received: NatsMessage[] = [];
+      const cb = (msg: NatsMessage) => received.push(msg);
+
+      const payload: NatsMessage = {
+        sender: "Bob",
+        text: "hi",
+        timestamp: new Date().toISOString(),
+      };
+      mockSubscribe.mockReturnValue(makeFakeSub(JSON.stringify(payload)));
+
+      await connect("ws://localhost:9222", "chat", "Alice", cb);
+
+      // Allow the async iterators to drain
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(received.length).toBeGreaterThan(0);
+      expect(received[0].sender).toBe("Bob");
+      expect(received[0].text).toBe("hi");
     });
   });
 
   describe("publish()", () => {
     it("publishes to the common topic", async () => {
-      await connect("ws://localhost:9222", "chat", "Alice");
+      await connect("ws://localhost:9222", "chat", "Alice", vi.fn());
       publish("hello");
 
       expect(mockPublish).toHaveBeenCalledOnce();
@@ -80,7 +107,7 @@ describe("NATS client", () => {
     });
 
     it("sends the correct JSON wire format", async () => {
-      await connect("ws://localhost:9222", "chat", "Alice");
+      await connect("ws://localhost:9222", "chat", "Alice", vi.fn());
       publish("hello");
 
       const rawPayload = mockPublish.mock.calls[0][1] as Uint8Array;
@@ -95,32 +122,9 @@ describe("NATS client", () => {
     });
   });
 
-  describe("onMessage()", () => {
-    it("invokes the callback for incoming messages", async () => {
-      const received: NatsMessage[] = [];
-      onMessage((msg) => received.push(msg));
-
-      const payload: NatsMessage = {
-        sender: "Bob",
-        text: "hi",
-        timestamp: new Date().toISOString(),
-      };
-      mockSubscribe.mockReturnValue(makeFakeSub(JSON.stringify(payload)));
-
-      await connect("ws://localhost:9222", "chat", "Alice");
-
-      // Allow the async iterators to drain
-      await new Promise((r) => setTimeout(r, 20));
-
-      expect(received.length).toBeGreaterThan(0);
-      expect(received[0].sender).toBe("Bob");
-      expect(received[0].text).toBe("hi");
-    });
-  });
-
   describe("disconnect()", () => {
     it("drains the connection", async () => {
-      await connect("ws://localhost:9222", "chat", "Alice");
+      await connect("ws://localhost:9222", "chat", "Alice", vi.fn());
       await disconnect();
 
       expect(mockDrainConn).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- Moves the message callback from a nullable module-level variable (`let messageCallback: MessageCallback | null = null`) into a required fourth parameter of `connect()`
- Removes the standalone `onMessage()` export — callers can no longer register the callback separately from connecting
- Updates `ChatView` to pass `appendMessage` directly as the fourth argument to `connect()`
- Updates all tests to match the new API signature

## Motivation

The old two-step `onMessage()` + `connect()` pattern was fragile: any caller that called `connect()` before `onMessage()` would silently drop early messages. The new API makes the dependency explicit at the type level — it's impossible to connect without providing a handler.

## Test plan

- [x] All 49 existing tests pass
- [x] New test: `connect() > accepts the onMessage callback as a required fourth argument`
- [x] New test: `connect() > invokes the callback for incoming messages passed at connect time`
- [x] Updated `ChatView` test: `connects to NATS on mount with callback as fourth argument`
- [x] `npm run lint` passes
- [x] `npm run format:check` passes

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)