### PR TITLE
fix: remove optimistic append to eliminate duplicate own messages

### DIFF
--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -54,8 +54,7 @@ function ChatView({ name, topic, natsUrl = "ws://localhost:9222" }: ChatViewProp
   function handleSend() {
     const trimmed = text.trim();
     if (!trimmed) return;
-    // Optimistic: add to local state immediately
-    appendMessage({ sender: name, text: trimmed, timestamp: new Date().toISOString() });
+    // Let the NATS echo be the single source of truth — avoids duplicate messages.
     publish(trimmed);
     setText("");
   }


### PR DESCRIPTION
## Summary

Fixes #15 — sender sees own messages twice.

- Removed the optimistic `appendMessage()` call from `ChatView.handleSend()`.
- The NATS echo on the subscribed topic is now the single source of truth for displaying sent messages.
- Replaced the test "shows own message immediately after sending (optimistic)" with two new tests:
  - Verifies the message does **not** appear immediately after sending (before echo).
  - Verifies the message **does** appear once the NATS echo arrives.

## Root Cause

`handleSend()` was calling `appendMessage()` optimistically before `publish()`. Because Alice is subscribed to the same topic she publishes to, the NATS server echoed the message back, triggering a second `appendMessage()` call — resulting in two identical entries.

## Test plan

- [ ] `npm test -- --run` — all 50 tests pass
- [ ] `npm run lint` — no lint errors
- [ ] `npm run format:check` — formatting is clean
- [ ] Open two chat windows (Alice and Bob), send a message from Alice — it appears **once** in her window (after the NATS round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)