### PR TITLE
feat: visual polish for chat UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/chatbot.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SocialBot</title>
   </head>

--- a/public/chatbot.svg
+++ b/public/chatbot.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#3b82f6">
+  <!-- Chat bubble with robot face -->
+  <path d="M20 2H4C2.9 2 2 2.9 2 4v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
+  <!-- Eyes -->
+  <circle cx="9" cy="10" r="1.5" fill="white"/>
+  <circle cx="15" cy="10" r="1.5" fill="white"/>
+  <!-- Mouth / antenna dots -->
+  <rect x="8" y="13.5" width="8" height="1.5" rx="0.75" fill="white"/>
+</svg>


### PR DESCRIPTION
Closes #23

## Summary
- Dynamic page title set to `topic.name` (e.g. `chat.room.Alice`) when connected, restored on disconnect
- Messages displayed in rounded chat bubbles: own messages right-aligned in blue, others left-aligned in gray
- Message input has a past-messages datalist dropdown (deduplicated, most-recent first)
- Replaced Vite logo favicon with a custom chatbot SVG icon
- Replaced "Send" button text with a right-pointing play arrow SVG (`aria-label="Send"` preserved for accessibility)

## Test plan
- [x] All 63 existing tests pass
- [x] 7 new tests cover: dynamic title set/restore, self vs. other bubble alignment (`data-sender` attribute), datalist presence, history population, deduplication
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)