### PR TITLE
fix: remove historyApiFallback removed in Vite 6

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,4 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   base: process.env.VITE_BASE_URL ?? "/",
-  server: {
-    historyApiFallback: true,
-  },
 });


### PR DESCRIPTION
## Summary
- Removes `historyApiFallback` from `vite.config.ts` — this option was removed from Vite 6's `ServerOptions` type and is now the default dev server behavior
- Fixes TS2769 type error that was causing the CI deploy job to fail on `main`

## Test plan
- [ ] CI passes (build step no longer errors on `tsc -b`)
- [ ] GitHub Pages deploy succeeds after merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)