### PR TITLE
feat: remove Leave chat button from BotChatView

### DIFF
--- a/src/bot/BotChatView.test.tsx
+++ b/src/bot/BotChatView.test.tsx
@@ -142,12 +142,4 @@ describe("BotChatView", () => {
     renderView({ thinking: false });
     expect(screen.queryByTestId("typing-indicator")).toBeNull();
   });
-
-  // Leave button
-  it("calls onLeave when the Leave chat button is clicked", () => {
-    const onLeave = vi.fn();
-    renderView({}, onLeave);
-    fireEvent.click(screen.getByRole("button", { name: /leave chat/i }));
-    expect(onLeave).toHaveBeenCalledTimes(1);
-  });
 });

--- a/src/bot/BotChatView.tsx
+++ b/src/bot/BotChatView.tsx
@@ -54,14 +54,6 @@ function BotChatView({ session, onLeave, client }: BotChatViewProps) {
         >
           {promptFilename}
         </button>
-        <span className="ml-auto">
-          <button
-            onClick={onLeave}
-            className="rounded bg-gray-200 px-3 py-1 text-sm hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-          >
-            Leave chat
-          </button>
-        </span>
       </header>
 
       {/* Error banner */}


### PR DESCRIPTION
## Summary

- Removed the redundant "Leave chat" button from the bot status bar header — closing the tab already disconnects the bot session
- Retained the `onLeave` prop and the "Back to login" button in the error banner, which remains useful for recovering from LLM errors
- Removed the corresponding test for the now-deleted button

🤖 Generated with [Claude Code](https://claude.com/claude-code)