### PR TITLE
ci: add preview deployments for non-main branches

### DIFF
--- a/.github/workflows/_build-and-deploy.yml
+++ b/.github/workflows/_build-and-deploy.yml
@@ -1,0 +1,44 @@
+name: Build and Deploy (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      preview:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  deploy:
+    name: ${{ inputs.preview && 'Build and Deploy Preview' || 'Build and Deploy to GitHub Pages' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - run: node scripts/generate-config.js demo-pages.yaml
+      - run: npm run build
+        env:
+          VITE_BASE_URL: /SocialBot/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deploy
+        uses: actions/deploy-pages@v4
+        with:
+          preview: ${{ inputs.preview }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,34 +3,19 @@ name: Deploy
 on:
   push:
     branches:
-      - main
+      - "**"
 
 jobs:
-  deploy:
-    name: Build and Deploy to GitHub Pages
-    runs-on: ubuntu-latest
+  preview:
+    if: github.ref != 'refs/heads/main'
+    uses: ./.github/workflows/_build-and-deploy.yml
+    with:
+      environment: preview
+      preview: true
 
-    permissions:
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-      - run: npm ci
-      - run: node scripts/generate-config.js demo-pages.yaml
-      - run: npm run build
-        env:
-          VITE_BASE_URL: /SocialBot/
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-      - id: deploy
-        uses: actions/deploy-pages@v4
+  production:
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/_build-and-deploy.yml
+    with:
+      environment: github-pages
+      preview: false


### PR DESCRIPTION
## Summary
- Extracts the 7-step build+deploy block into a reusable workflow (`.github/workflows/_build-and-deploy.yml`)
- Rewrites `deploy.yml` to call the reusable workflow for both preview (non-`main` branches) and production (`main`)
- Preview deployments create a GitHub Deployment record visible on the PR page, enabling it as a QA merge gate

## Manual setup required before the workflow runs successfully
1. **Create the `preview` environment**: `Settings → Environments → New environment`, name `preview`, Deployment branches: All branches
2. After the first preview job completes, note the exact check name and add it as a required status check on the `main` branch protection rule

## Test plan
- [ ] Push feature branch → confirm `preview / Build and Deploy Preview` check appears in Actions
- [ ] Open PR → confirm deployment record appears under "Deployments" with a "View deployment" link
- [ ] Merge to `main` → confirm `production` job runs, `preview` job is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)