### PR TITLE
feat: remove top header bar, move NATS topic to sidebar footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,7 +171,7 @@ function App({ initialAgents }: AppProps) {
         <div className="border-t border-gray-200 p-2 dark:border-gray-700">
           {sharedTopic && (
             <div
-              className="mb-1 truncate px-1 font-mono text-xs text-green-400"
+              className="mb-1 truncate px-1 text-center font-mono text-xs text-green-400"
               title={sharedTopic}
             >
               {sharedTopic}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -169,6 +169,14 @@ function App({ initialAgents }: AppProps) {
 
         {/* Theme toggle + Add tab button */}
         <div className="border-t border-gray-200 p-2 dark:border-gray-700">
+          {sharedTopic && (
+            <div
+              className="mb-1 truncate px-1 font-mono text-xs text-green-400"
+              title={sharedTopic}
+            >
+              {sharedTopic}
+            </div>
+          )}
           <button
             onClick={toggle}
             aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
@@ -186,19 +194,8 @@ function App({ initialAgents }: AppProps) {
         </div>
       </nav>
 
-      {/* Main column: global header + content area */}
+      {/* Main column: content area */}
       <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Global header — shared NATS topic */}
-        <header className="flex items-center border-b border-gray-200 px-4 py-2 dark:border-gray-700">
-          <span className="font-semibold text-gray-900 dark:text-white">SocialBot</span>
-          {sharedTopic && (
-            <>
-              <span className="mx-2 text-gray-400 dark:text-gray-500">·</span>
-              <span className="font-mono text-sm text-green-400">{sharedTopic}</span>
-            </>
-          )}
-        </header>
-
         {/* Content area — all tabs rendered simultaneously; inactive ones hidden */}
         <div className="relative flex flex-1 overflow-hidden">
           {tabs.map((tab) => (


### PR DESCRIPTION
## Summary
- Removes the global \"SocialBot\" header bar from the top of the main content area
- Moves the shared NATS topic prefix display into the sidebar footer, above the theme toggle and add-tab buttons
- Topic is truncated with a `title` attribute so long topics don't break the sidebar layout but are readable on hover

## Test plan
- [x] `npm start` — no top bar visible; sidebar footer shows toggle + add button; no NATS topic shown (no connected agents)
- [x] `npm start -- demo.yaml` — topic prefix appears in sidebar footer once agents connect; no top bar
- [x] Toggle dark/light mode still works
- [x] `npm test` — all 187 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)